### PR TITLE
Feature/voice api testing

### DIFF
--- a/backend/app/api/v1/endpoints/voice.py
+++ b/backend/app/api/v1/endpoints/voice.py
@@ -1,15 +1,17 @@
-﻿from datetime import datetime, timezone
+﻿from datetime import datetime, timezone, timedelta
 from typing import Optional
-from uuid import UUID
 import uuid
+from uuid import UUID
 import os
 import tempfile
 import time
 import logging
+import hashlib
 
 import anyio
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+import sqlalchemy as sa
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.schemas import (
@@ -23,29 +25,59 @@ from app.services.s3 import S3Service
 from app.database import get_db
 from app.models import EmotionLog
 
+# -------------------------------------------------
+# Router / Logger
+# -------------------------------------------------
 router = APIRouter(prefix="/voice", tags=["voice"])
 
-logging.basicConfig(level=logging.INFO, force=True)
-logging.getLogger().setLevel(logging.INFO)
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
-handler = logging.StreamHandler()
-handler.setLevel(logging.INFO)
-logger.addHandler(handler)
+# -------------------------------------------------
+# Helpers (JST / UUID / intensity / lock key)
+# -------------------------------------------------
+JST = timezone(timedelta(hours=9))
 
-# 強度レベルの文字列を数値IDに変換する関数
-def convert_intensity_level(level_str: str) -> int:
-    intensity_mapping = {
-        'low': 1,
-        'medium': 2,
-        'high': 3
-    }
-    # デフォルトは2（中程度）を返す
-    logger.info(f"🔢 強度レベル変換: '{level_str}' → {intensity_mapping.get(level_str, 2)}")
-    return intensity_mapping.get(level_str, 2)
+def _to_uuid(v) -> UUID:
+    if isinstance(v, UUID):
+        return v
+    try:
+        return UUID(str(v))
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid UUID")
 
-# バリデーション
+def _to_intensity_id(v) -> int:
+    """
+    'low'|'medium'|'high' or 1|2|3 を受け付ける。
+    不正値は 2 (medium) にフォールバック。
+    """
+    mapping = {"low": 1, "medium": 2, "high": 3}
+    if isinstance(v, str):
+        s = v.strip().lower()
+        if s in mapping:
+            return mapping[s]
+        if s.isdigit() and int(s) in (1, 2, 3):
+            return int(s)
+        return 2
+    if isinstance(v, int) and v in (1, 2, 3):
+        return v
+    return 2
+
+def _today_jst_date():
+    return datetime.now(JST).date()  # YYYY-MM-DD (JST)
+
+def _stable_lock_key(user_id: UUID, child_id: UUID, jst_date) -> int:
+    """
+    pg_advisory_xact_lock は bigint を受け取る。
+    Pythonのhashはプロセスで変わるため、SHA-1の下位63bitで安定キー生成。
+    """
+    seed = f"{user_id}:{child_id}:{jst_date.isoformat()}".encode("utf-8")
+    h = hashlib.sha1(seed).digest()
+    n = int.from_bytes(h[-8:], "big") & 0x7FFFFFFFFFFFFFFF  # 符号なし63bit
+    return n
+
+# -------------------------------------------------
+# Validation for local audio
+# -------------------------------------------------
 def _validate_local_audio_file(path: str, language: str) -> None:
     ALLOWED_EXT = {"webm", "wav", "mp3", "m4a"}
     ALLOWED_LANG = {"ja", "en"}
@@ -72,40 +104,30 @@ def _validate_local_audio_file(path: str, language: str) -> None:
     
     logger.info(f"✅ バリデーション完了: {path}, サイズ: {size} bytes, 形式: {ext}, 言語: {language}")
 
-
-# --- WhisperService をプロセス内シングルトンで使い回す -------------------
+# -------------------------------------------------
+# Whisper singleton
+# -------------------------------------------------
 _whisper_service: Optional[WhisperService] = None
 def get_whisper_service() -> WhisperService:
     global _whisper_service
     if _whisper_service is None:
         logger.info(" WhisperService: 初期化開始 (singleton)")
         _whisper_service = WhisperService()
-        logger.info("✅ WhisperService: 初期化完了")
+        logger.info(" WhisperService: 初期化完了")
     return _whisper_service
 
-
-@router.get(
-    "/health",
-    summary="音声APIヘルスチェック",
-    description="音声APIの稼働状態を確認",
-    responses={
-        200: {
-            "description": "サービス稼働中",
-            "content": {
-                "application/json": {
-                    "example": {"status": "healthy", "service": "voice-api"}
-                }
-            },
-        }
-    },
-)
+# -------------------------------------------------
+# Health
+# -------------------------------------------------
+@router.get("/health", summary="音声APIヘルスチェック", description="音声APIの稼働状態を確認")
 async def health_check():
     logger.info("🔍 ヘルスチェック開始")
-    logger.debug("health_check: ok")
     logger.info("✅ ヘルスチェック完了")
     return {"status": "healthy", "service": "voice-api"}
 
-
+# -------------------------------------------------
+# Transcribe
+# -------------------------------------------------
 @router.post(
     "/transcribe",
     response_model=VoiceTranscribeResponse,
@@ -120,16 +142,9 @@ async def transcribe_voice(
     request: VoiceTranscribeRequest,
     whisper: WhisperService = Depends(get_whisper_service),
 ) -> VoiceTranscribeResponse:
-    """
-    audio_file_path の許可形式:
-      - 'audio/<uuid>/xxx.ext'     ← S3キー（推奨）
-      - 's3://bucket-name/audio/..'← s3 URI
-      - '/tmp/xxx.wav'             ← ローカル絶対パス（内部用）
-    """
     s3 = S3Service()
     tmp_path: Optional[str] = None
 
-    # 入口ログ（パスの"種類"だけ出す）
     p = request.audio_file_path
     path_kind = (
         "local" if (os.path.isabs(p) and os.path.exists(p))
@@ -137,131 +152,88 @@ async def transcribe_voice(
         else "http" if p.startswith(("http://", "https://"))
         else "s3key"
     )
-    logger.info(
-        f" 音声認識開始: パス種類={path_kind}, 言語={request.language}, ファイル={p}"
-    )
+    logger.info(f" 音声認識開始: 種類={path_kind}, 言語={request.language}, ファイル={p}")
 
     t0 = time.monotonic()
     try:
-        # 1) ローカル絶対パス
         if path_kind == "local":
             local_path = p
-            logger.info(f"📁 ローカルパスを使用: {local_path}")
-
-        # 2) s3://bucket/key
         elif path_kind == "s3uri":
             rest = p.replace("s3://", "", 1)
             bucket, key = rest.split("/", 1)
             suffix = os.path.splitext(key)[1] or ".wav"
             fd, tmp_path = tempfile.mkstemp(suffix=suffix)
             os.close(fd)
-            logger.info(f" S3ダウンロード開始: bucket={bucket}, key={key}, tmp={tmp_path}")
+            logger.info(f" S3ダウンロード: bucket={bucket}, key={key}, tmp={tmp_path}")
             s3.download_file(s3_key=key, local_file_path=tmp_path, bucket_name=bucket)
-            size = os.path.getsize(tmp_path)
-            logger.info(f"✅ S3ダウンロード完了: {tmp_path}, サイズ: {size} bytes")
             local_path = tmp_path
-
-        # 3) S3キー（例: 'audio/<uuid>/xxx.ext'）
         elif path_kind == "s3key":
             suffix = os.path.splitext(p)[1] or ".wav"
             fd, tmp_path = tempfile.mkstemp(suffix=suffix)
             os.close(fd)
-            logger.info(f" S3ダウンロード開始: bucket={s3.bucket_name}, key={p}, tmp={tmp_path}")
+            logger.info(f" S3ダウンロード: bucket={s3.bucket_name}, key={p}, tmp={tmp_path}")
             try:
                 s3.download_file(s3_key=p, local_file_path=tmp_path, bucket_name=s3.bucket_name)
-                logger.info(f"✅ S3ダウンロード完了: {tmp_path}")
             except Exception as e:
-                logger.error(f"❌ S3ダウンロードエラー: {e}")
                 logger.exception("s3 download: error")
                 raise HTTPException(status_code=500, detail=f"S3ダウンロードエラー: {str(e)}")
-            
             if not os.path.exists(tmp_path) or os.path.getsize(tmp_path) == 0:
-                logger.error(f"❌ S3からのファイルダウンロードに失敗しました: {tmp_path}")
                 raise HTTPException(status_code=400, detail="S3からのファイルダウンロードに失敗しました")
-            
-            size = os.path.getsize(tmp_path)
-            logger.info(f"✅ S3ダウンロード完了: {tmp_path}, サイズ: {size} bytes")
             local_path = tmp_path
-
-        # 4) http(s) 未対応
         else:
-            logger.warning(f"⚠️ HTTP(S)は未対応: {p}")
             raise HTTPException(status_code=400, detail="HTTP(S)の音声URLは未対応です。S3キーか s3:// を渡してください。")
 
-        # 事前バリデーション
-        logger.info(f"🔍 ファイルバリデーション開始: {local_path}")
         _validate_local_audio_file(local_path, request.language)
 
-        # Whisper は同期API → スレッドで実行
         t1 = time.monotonic()
-        logger.info(f"🤖 Whisper処理開始: {local_path}")
         result = await anyio.to_thread.run_sync(
-            lambda: whisper.transcribe_audio(
-                local_path,
-                language=request.language or "ja",
-            )
+            lambda: whisper.transcribe_audio(local_path, language=request.language or "ja")
         )
         t2 = time.monotonic()
-        whisper_time = round(t2 - t1, 2)
-        text_length = len(result.get("text", ""))
-        detected_lang = result.get("language")
-        logger.info(
-            f"✅ Whisper処理完了: 処理時間={whisper_time}秒, 文字数={text_length}, 検出言語={detected_lang}"
-        )
 
         resp = VoiceTranscribeResponse(
             success=True,
-            transcription_id=0,  # 追ってDB保存する場合は実IDを返す
+            transcription_id=0,
             text=result.get("text", ""),
-            confidence=float(result.get("confidence", 0.0))
-            if isinstance(result.get("confidence", 0.0), (int, float))
-            else 0.0,
+            confidence=float(result.get("confidence", 0.0)) if isinstance(result.get("confidence", 0.0), (int, float)) else 0.0,
             language=result.get("language", request.language or "ja"),
             duration=float(result.get("duration", 0.0)),
             processed_at=datetime.now(timezone.utc),
         )
-        total_time = round(time.monotonic() - t0, 2)
-        logger.info(f"🎉 音声認識完了: 総処理時間={total_time}秒, 文字数={text_length}")
+        logger.info(f"✅ Whisper完了: {round(t2 - t1, 2)}秒 / 総処理 {round(time.monotonic()-t0,2)}秒")
         return resp
 
     except HTTPException:
-        logger.error(f"❌ HTTPException発生: 音声認識失敗")
         raise
     except Exception as e:
-        logger.error(f"❌ 予期しないエラー: {type(e).__name__}: {e}")
         logger.exception("transcribe: failed")
         raise HTTPException(status_code=500, detail=f"Transcription failed: {type(e).__name__}: {e}")
     finally:
         if tmp_path and os.path.exists(tmp_path):
             try:
                 os.remove(tmp_path)
-                logger.debug(f"🧹 一時ファイル削除完了: {tmp_path}")
             except Exception:
                 logger.warning(f"⚠️ 一時ファイル削除失敗: {tmp_path}")
 
-
+# -------------------------------------------------
+# Presign
+# -------------------------------------------------
 @router.post(
     "/get-upload-url",
     summary="アップロード用Presigned URL取得",
     description=(
         "S3に直接アップロードするための署名付きPUT URLを発行\n"
-        "- リクエストで `file_type`（'audio' | 'text'）と `file_format`（例: 'webm' | 'wav' | 'mp3' | 'm4a' | 'txt'）を指定。\n"
-        "- レスポンスの `upload_url` に、フロントから `PUT`（ヘッダ Content-Type は `content_type` をそのまま送る）。\n"
-        "- `file_path` はDBに保存するべき **S3のキー**。"
+        "- `file_type`: 'audio' | 'text'\n"
+        "- `file_format`: 例 'webm' | 'wav' | 'mp3' | 'm4a' | 'txt'\n"
+        "- `file_path` はDBに保存するべき **S3のキー**"
     ),
 )
 async def get_upload_url(request: VoiceUploadRequest, db: AsyncSession = Depends(get_db)):
     s3 = S3Service()
     t0 = time.monotonic()
     try:
-        # ファイル名用の一意ID
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         unique_id = str(uuid.uuid4())[:8]
-        logger.info(
-            f" Presigned URL生成開始: user_id={request.user_id}, file_type={request.file_type}, file_format={request.file_format}"
-        )
-
-        # ---- file_type ごとに拡張子とContent-Typeを決定 ----
         if request.file_type == "audio":
             if request.file_format == "webm":
                 ext, content_type = "webm", "audio/webm"
@@ -273,31 +245,19 @@ async def get_upload_url(request: VoiceUploadRequest, db: AsyncSession = Depends
                 ext, content_type = "m4a", "audio/mp4"
             else:
                 ext, content_type = "wav", "audio/wav"
-
             file_path = f"audio/{request.user_id}/audio_{timestamp}_{unique_id}.{ext}"
-            logger.info(f" 音声ファイル設定: 拡張子={ext}, Content-Type={content_type}")
-
         elif request.file_type == "text":
             ext, content_type = "txt", "text/plain"
             file_path = f"text/{request.user_id}/transcript_{timestamp}_{unique_id}.{ext}"
-            logger.info(f"📝 テキストファイル設定: 拡張子={ext}, Content-Type={content_type}")
-
         else:
-            logger.warning(f"❌ 無効なfile_type: {request.file_type}")
             raise HTTPException(status_code=400, detail="Invalid file type")
 
-        logger.info(f" S3 Presigned URL生成中: {file_path}")
         presigned_url = s3.generate_presigned_upload_url(file_path, content_type)
         if not presigned_url:
-            logger.error(f"❌ Presigned URL生成失敗: {file_path}")
             raise HTTPException(status_code=500, detail="Failed to generate upload URL")
 
-        # URL本体はログに出さない（秘匿）→長さのみ
-        url_length = len(presigned_url)
         processing_time = round(time.monotonic() - t0, 2)
-        logger.info(
-            f"✅ Presigned URL生成完了: key={file_path}, content_type={content_type}, url_length={url_length}, 処理時間={processing_time}秒"
-        )
+        logger.info(f"✅ Presigned URL: key={file_path}, type={content_type}, 処理={processing_time}秒")
         return {
             "success": True,
             "upload_url": presigned_url,
@@ -305,85 +265,129 @@ async def get_upload_url(request: VoiceUploadRequest, db: AsyncSession = Depends
             "s3_url": s3.get_file_url(file_path),
             "content_type": content_type,
         }
-
     except HTTPException:
-        logger.error(f"❌ HTTPException発生: Presigned URL生成失敗")
         raise
     except Exception as e:
-        logger.error(f"❌ 予期しないエラー: {type(e).__name__}: {e}")
         logger.exception("presign: failed")
         raise HTTPException(status_code=500, detail=str(e))
 
-
+# -------------------------------------------------
+# SAVE (Advisory lock: DELETE → INSERT)
+# -------------------------------------------------
 @router.post(
     "/save-record",
-    summary="ファイルキー保存",
-    description="音声・文字ファイルのS3キーをデータベースに保存（URLは保存しない）",
+    summary="その日の記録を置き換え保存（アドバイザリロックで直列化、マイグレ不要）",
+    description="(user_id, child_id, JST日付) 単位で排他。既存があれば削除→新規1件を挿入。",
 )
 async def save_record(request: VoiceSaveRequest, db: AsyncSession = Depends(get_db)):
     s3 = S3Service()
     t0 = time.monotonic()
+
+    # S3キー正規化
+    def to_key(p: Optional[str]) -> Optional[str]:
+        if not p:
+            return None
+        prefix = f"s3://{s3.bucket_name}/"
+        if p.startswith(prefix):
+            return p.replace(prefix, "")
+        if p.startswith(("http://", "https://")):
+            from urllib.parse import urlparse, unquote
+            u = urlparse(p)
+            path = unquote(u.path.lstrip("/"))
+            if path.startswith(f"{s3.bucket_name}/"):
+                return path[len(s3.bucket_name) + 1 :]
+            return path
+        return p
+
     try:
-        # "s3://<bucket>/..." や "https://..." が来た場合も key に正規化して保存
-        def to_key(p: Optional[str]) -> Optional[str]:
-            if not p:
-                return None
-            prefix = f"s3://{s3.bucket_name}/"
-            if p.startswith(prefix):
-                return p.replace(prefix, "")
-            if p.startswith(("http://", "https://")):
-                from urllib.parse import urlparse, unquote
-                u = urlparse(p)
-                path = unquote(u.path.lstrip("/"))
-                if path.startswith(f"{s3.bucket_name}/"):
-                    return path[len(s3.bucket_name) + 1 :]
-                return path
-            return p
+        # 必須
+        if not (request.user_id and request.child_id and request.emotion_card_id and request.intensity_id):
+            raise HTTPException(status_code=400, detail="user_id, child_id, emotion_card_id, intensity_id は必須です。")
+
+        user_id = _to_uuid(request.user_id)
+        child_id = _to_uuid(request.child_id)
+        emotion_card_id = _to_uuid(request.emotion_card_id)
+        intensity_id = _to_intensity_id(request.intensity_id)
 
         audio_key = to_key(request.audio_file_path)
-        text_key = to_key(request.text_file_path)
-        logger.info(
-            f"💾 記録保存開始: user_id={request.user_id}, audio_key={bool(audio_key)}, text_key={bool(text_key)}"
-        )
+        text_key  = to_key(request.text_file_path)
 
-        # 感情データのフィールドを追加
-        if not request.emotion_card_id or not request.intensity_id or not request.child_id:
-            raise HTTPException(
-                status_code=400, 
-                detail="emotion_card_id, intensity_id, and child_id are required"
+        jst_date = _today_jst_date()
+        lock_k = _stable_lock_key(user_id, child_id, jst_date)
+
+        # 古いS3の孤児掃除用に一時保管
+        old_audio_keys: list[str] = []
+        old_text_keys: list[str]  = []
+
+        async with db.begin():
+            # 同日同ユーザー×子どもで直列化
+            await db.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": lock_k})
+
+            # 当日(JST)の既存行を削除しつつ、古いキーを回収
+            res_del = await db.execute(
+                sa.text("""
+                    DELETE FROM emotion_logs
+                    WHERE user_id = :uid
+                      AND child_id = :cid
+                      AND DATE(created_at AT TIME ZONE 'Asia/Tokyo') = :d
+                    RETURNING audio_file_path, text_file_path
+                """),
+                {"uid": user_id, "cid": child_id, "d": jst_date}
             )
-        
-        voice_record = EmotionLog(
-            user_id=request.user_id,
-            audio_file_path=audio_key,
-            text_file_path=text_key,
-            # 感情データのフィールドを追加
-            emotion_card_id=uuid.UUID(request.emotion_card_id),
-            intensity_id=convert_intensity_level(request.intensity_id),
-            child_id=uuid.UUID(request.child_id),
-        )
+            for a, t in res_del.fetchall():
+                if a: old_audio_keys.append(a)
+                if t: old_text_keys.append(t)
 
-        logger.info(f" EmotionLog作成: id={voice_record.id}")
-        db.add(voice_record)
-        await db.commit()
-        await db.refresh(voice_record)
-        logger.info(f"✅ データベース保存完了: record_id={voice_record.id}")
+            # 新規1件を挿入
+            insert_sql = sa.text("""
+                INSERT INTO emotion_logs
+                    (id, user_id, child_id, emotion_card_id, intensity_id,
+                     voice_note, text_file_path, audio_file_path,
+                     created_at, updated_at)
+                VALUES
+                    (:id, :uid, :cid, :eid, :iid,
+                     :note, :textp, :audiop,
+                     now(), now())
+                RETURNING id
+            """)
+            new_id = uuid.uuid4()
+            res = await db.execute(insert_sql, {
+                "id": new_id,
+                "uid": user_id,
+                "cid": child_id,
+                "eid": emotion_card_id,
+                "iid": int(intensity_id),
+                "note": None,         # voice_note 使うなら適宜
+                "textp": text_key,
+                "audiop": audio_key,
+            })
+            record_id = res.scalar_one()
+
+        # Tx後に古いS3を削除（DBは確定済み。失敗は警告ログに留める）
+        for key in [*old_audio_keys, *old_text_keys]:
+            try:
+                if key:
+                    s3.delete_object(key)
+            except Exception as e:
+                logger.warning(f"[S3] old object delete failed: key={key} err={e}")
 
         processing_time = round(time.monotonic() - t0, 2)
-        logger.info(f"🎉 記録保存完了: record_id={voice_record.id}, 処理時間={processing_time}秒")
+        logger.info(f"✅ 置き換え保存完了 (locked): record_id={record_id}, jst_date={jst_date}, 処理時間={processing_time}秒")
         return {
             "success": True,
-            "record_id": voice_record.id,
-            "message": "Record saved successfully",
+            "record_id": str(record_id),
+            "message": "Record saved (replaced) successfully",
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"❌ 記録保存エラー: {type(e).__name__}: {e}")
-        await db.rollback()
-        logger.exception("save-record: failed")
+        logger.exception("save-record advisory-lock replace: failed")
         raise HTTPException(status_code=500, detail=str(e))
 
-
+# -------------------------------------------------
+# Records list
+# -------------------------------------------------
 @router.get(
     "/records/{user_id}",
     summary="記録一覧取得",
@@ -402,15 +406,15 @@ async def get_records(user_id: UUID, db: AsyncSession = Depends(get_db)):
         result = await db.execute(query)
         records = result.scalars().all()
         record_count = len(records)
-        logger.info(f"📊 データベースから記録取得完了: {record_count}件")
+        logger.info(f"📊 取得完了: {record_count}件")
 
         def to_key(p: Optional[str]) -> Optional[str]:
             if not p:
                 return None
             prefix = f"s3://{s3.bucket_name}/"
-            if p.startswith(prefix):
+            if isinstance(p, str) and p.startswith(prefix):
                 return p.replace(prefix, "")
-            if p.startswith(("http://", "https://")):
+            if isinstance(p, str) and p.startswith(("http://", "https://")):
                 from urllib.parse import urlparse, unquote
                 u = urlparse(p)
                 path = unquote(u.path.lstrip("/"))
@@ -444,10 +448,9 @@ async def get_records(user_id: UUID, db: AsyncSession = Depends(get_db)):
             ],
         }
         processing_time = round(time.monotonic() - t0, 2)
-        logger.info(f"✅ 記録一覧取得完了: {record_count}件, 処理時間={processing_time}秒")
+        logger.info(f"✅ 一覧取得完了: {record_count}件, 処理時間={processing_time}秒")
         return payload
 
     except Exception as e:
-        logger.error(f"❌ 記録一覧取得エラー: {type(e).__name__}: {e}")
         logger.exception("records: failed")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/api/v1/endpoints/voice.py
+++ b/backend/app/api/v1/endpoints/voice.py
@@ -271,6 +271,11 @@ async def get_upload_url(request: VoiceUploadRequest, db: AsyncSession = Depends
     description="(user_id, child_id, JST日付) 単位で排他。既存があれば削除→新規1件を挿入。",
 )
 async def save_record(request: VoiceSaveRequest, db: AsyncSession = Depends(get_db)):
+    # デバッグログ追加
+    print(f"[DEBUG] Request body: {request}")
+    print(f"[DEBUG] voice_note: {request.voice_note}")
+    print(f"[DEBUG] voice_note type: {type(request.voice_note)}")
+    
     s3 = S3Service()
     t0 = time.monotonic()
 
@@ -339,13 +344,17 @@ async def save_record(request: VoiceSaveRequest, db: AsyncSession = Depends(get_
                 RETURNING id
             """)
             new_id = uuid.uuid4()
+            
+            # voice_noteを実際のリクエストから取得
+            voice_note = request.voice_note if request.voice_note is not None else ""
+            
             res = await db.execute(insert_sql, {
                 "id": new_id,
                 "uid": user_id,
                 "cid": child_id,
                 "eid": emotion_card_id,
                 "iid": int(intensity_id),
-                "note": None,         # voice_note 使うなら適宜
+                "note": voice_note,    # 修正: Noneではなく実際のvoice_noteを使用
                 "textp": text_key,
                 "audiop": audio_key,
             })

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -118,15 +118,15 @@ class VoiceUploadRequest(StrictModel):
 class VoiceSaveRequest(StrictModel):
     user_id: UUID = Field(..., description="ユーザーID（UUID）",
                           example="user-uuid-example")
-    # 「S3キー or s3://URI」を受ける（https は未対応）
+    # S3キーを受ける（https は未対応）
     audio_file_path: str = Field(
         ...,
-        description="音声ファイルの S3 キー or s3://URI（例: audio/<uuid>/audio_YYYYMMDD_HHMMSS_xxx.webm または s3://bucket/key.webm）",
+        description="音声ファイルのS3キー（例: audio/<uuid>/audio_YYYYMMDD_HHMMSS_xxx.webm）",
         example="audio/user-uuid-example/audio_YYYYMMDD_HHMMSS_xxx.webm",
     )
     text_file_path: Optional[str] = Field(
         None,
-        description="テキストファイルの S3 キー or s3://URI（任意）",
+        description="テキストファイルのS3キー（任意）",
         example="text/user-uuid-example/transcription_audio_YYYYMMDD_HHMMSS_xxx.txt",
     )
     # 感情データのフィールドを追加
@@ -150,10 +150,10 @@ class VoiceSaveRequest(StrictModel):
     @classmethod
     def validate_audio_key(cls, v: str) -> str:
         if v.startswith(("http://", "https://")):
-            raise ValueError("HTTP(S)のURLは未対応です。S3キー（例: 'audio/...') か s3:// を渡してください。")
-        if v.startswith("s3://") or "://" not in v:
+            raise ValueError("HTTP(S)のURLは未対応です。S3キー（例: 'audio/...') を渡してください。")
+        if "://" not in v:
             return v
-        raise ValueError("サポートされないパス形式です。S3キー（例: 'audio/...') か s3:// を渡してください。")
+        raise ValueError("サポートされないパス形式です。S3キー（例: 'audio/...') を渡してください。")
 
     @field_validator("text_file_path")
     @classmethod
@@ -161,10 +161,10 @@ class VoiceSaveRequest(StrictModel):
         if v is None:
             return v
         if v.startswith(("http://", "https://")):
-            raise ValueError("HTTP(S)のURLは未対応です。S3キー（例: 'text/...') か s3:// を渡してください。")
-        if v.startswith("s3://") or "://" not in v:
+            raise ValueError("HTTP(S)のURLは未対応です。S3キー（例: 'text/...') を渡してください。")
+        if "://" not in v:
             return v
-        raise ValueError("サポートされないパス形式です。S3キー（例: 'text/...') か s3:// を渡してください。")
+        raise ValueError("サポートされないパス形式です。S3キー（例: 'text/...') を渡してください。")
 
 
 class VoiceTranscribeRequest(StrictModel):
@@ -172,7 +172,7 @@ class VoiceTranscribeRequest(StrictModel):
                           example="user-uuid-example")
     audio_file_path: str = Field(
         ...,
-        description="音声ファイルの S3 キー or s3://URI（例: audio/<uuid>/xxx.webm または s3://bucket/key.webm）",
+        description="音声ファイルのS3キー（例: audio/<uuid>/xxx.webm）",
         example="audio/user-uuid-example/audio_YYYYMMDD_HHMMSS_xxx.webm",
     )
     # Whisper に 'auto' を渡す運用は外し、ja/en に限定
@@ -184,10 +184,10 @@ class VoiceTranscribeRequest(StrictModel):
     @classmethod
     def validate_audio_file_path(cls, v: str) -> str:
         if v.startswith(("http://", "https://")):
-            raise ValueError("HTTP(S)の音声URLは未対応です。S3キー（例: 'audio/...') か s3:// を渡してください。")
-        if v.startswith("s3://") or "://" not in v:
+            raise ValueError("HTTP(S)の音声URLは未対応です。S3キー（例: 'audio/...') を渡してください。")
+        if "://" not in v:
             return v
-        raise ValueError("サポートされないパス形式です。S3キー（例: 'audio/...') か s3:// を渡してください。")
+        raise ValueError("サポートされないパス形式です。S3キー（例: 'audio/...') を渡してください。")
 
 
 # ===== Response =====
@@ -199,7 +199,7 @@ class VoiceUploadResponse(StrictModel):
         description="保存用の S3 キー（例: audio/<uuid>/audio_YYYYMMDD_HHMMSS_xxx.webm）",
         example="audio/user-uuid-example/audio_YYYYMMDD_HHMMSS_xxx.webm",
     )
-    s3_url: AnyUrl = Field(..., description="S3上/HTTPSのファイルURL（https:// または s3://）")
+    s3_url: AnyUrl = Field(..., description="S3上のファイルURL（https://）")
     content_type: str = Field(..., description="ファイルのContent-Type（例: audio/webm）", example="audio/webm")
 
     @field_validator("content_type")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -108,7 +108,7 @@ class StrictModel(BaseModel):
 # ===== Request =====
 class VoiceUploadRequest(StrictModel):
     user_id: UUID = Field(..., description="ユーザーID（UUID）",
-                          example="06c0c0fa-261f-4033-a40f-29c0724abdc4")
+                          example="user-uuid-example")
     file_type: AllowedFileType = Field(..., description="ファイルタイプ", example="audio")
     file_format: AllowedFileFormat = Field(
         default="webm", description="ファイル形式（webm/wav/mp3/m4a）", example="webm"
@@ -117,17 +117,17 @@ class VoiceUploadRequest(StrictModel):
 
 class VoiceSaveRequest(StrictModel):
     user_id: UUID = Field(..., description="ユーザーID（UUID）",
-                          example="06c0c0fa-261f-4033-a40f-29c0724abdc4")
+                          example="user-uuid-example")
     # 「S3キー or s3://URI」を受ける（https は未対応）
     audio_file_path: str = Field(
         ...,
         description="音声ファイルの S3 キー or s3://URI（例: audio/<uuid>/audio_YYYYMMDD_HHMMSS_xxx.webm または s3://bucket/key.webm）",
-        example="audio/06c0c0fa-261f-4033-a40f-29c0724abdc4/audio_20250818_210836_5135bbf0.webm",
+        example="audio/user-uuid-example/audio_YYYYMMDD_HHMMSS_xxx.webm",
     )
     text_file_path: Optional[str] = Field(
         None,
         description="テキストファイルの S3 キー or s3://URI（任意）",
-        example="text/06c0c0fa-261f-4033-a40f-29c0724abdc4/transcription_audio_20250818_210836_5135bbf0.txt",
+        example="text/user-uuid-example/transcription_audio_YYYYMMDD_HHMMSS_xxx.txt",
     )
     # 感情データのフィールドを追加
     emotion_card_id: str = Field(
@@ -143,7 +143,7 @@ class VoiceSaveRequest(StrictModel):
     child_id: str = Field(
         ...,
         description="子供ID（必須）",
-        example="41489976-63ee-4332-85f4-6d9200a79bfc"
+        example="child-uuid-example"
     )
 
     @field_validator("audio_file_path")
@@ -169,11 +169,11 @@ class VoiceSaveRequest(StrictModel):
 
 class VoiceTranscribeRequest(StrictModel):
     user_id: UUID = Field(..., description="ユーザーID（UUID）",
-                          example="06c0c0fa-261f-4033-a40f-29c0724abdc4")
+                          example="user-uuid-example")
     audio_file_path: str = Field(
         ...,
         description="音声ファイルの S3 キー or s3://URI（例: audio/<uuid>/xxx.webm または s3://bucket/key.webm）",
-        example="audio/06c0c0fa-261f-4033-a40f-29c0724abdc4/audio_20250818_210836_5135bbf0.webm",
+        example="audio/user-uuid-example/audio_YYYYMMDD_HHMMSS_xxx.webm",
     )
     # Whisper に 'auto' を渡す運用は外し、ja/en に限定
     language: Literal["ja", "en"] = Field(
@@ -197,7 +197,7 @@ class VoiceUploadResponse(StrictModel):
     file_path: str = Field(
         ...,
         description="保存用の S3 キー（例: audio/<uuid>/audio_YYYYMMDD_HHMMSS_xxx.webm）",
-        example="audio/06c0c0fa-261f-4033-a40f-29c0724abdc4/audio_20250818_210836_5135bbf0.webm",
+        example="audio/user-uuid-example/audio_YYYYMMDD_HHMMSS_xxx.webm",
     )
     s3_url: AnyUrl = Field(..., description="S3上/HTTPSのファイルURL（https:// または s3://）")
     content_type: str = Field(..., description="ファイルのContent-Type（例: audio/webm）", example="audio/webm")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -129,6 +129,11 @@ class VoiceSaveRequest(StrictModel):
         description="テキストファイルのS3キー（任意）",
         example="text/user-uuid-example/transcription_audio_YYYYMMDD_HHMMSS_xxx.txt",
     )
+    voice_note: Optional[str] = Field(
+        None,
+        description="音声認識テキスト（任意）",
+        example="今日は楽しかった"
+    )
     # 感情データのフィールドを追加
     emotion_card_id: str = Field(
         ...,

--- a/backend/app/services/s3.py
+++ b/backend/app/services/s3.py
@@ -55,8 +55,8 @@ class S3Service:
             raise S3UploadError(f"ファイルのアップロードに失敗しました: {e}")
 
     def get_file_url(self, file_path: str) -> str:
-        """S3ファイルのURLを取得（s3:// 形式）"""
-        return f"s3://{self.bucket_name}/{file_path}"
+        """S3ファイルのHTTPS URLを取得"""
+        return f"https://{self.bucket_name}.s3.amazonaws.com/{file_path}"
 
     def generate_presigned_upload_url(
         self,

--- a/backend/app/services/voice/file_ops.py
+++ b/backend/app/services/voice/file_ops.py
@@ -123,7 +123,7 @@ class VoiceFileService:
             return {
                 "success": True,
                 "s3_key": s3_key,
-                "s3_url": f"s3://{self.bucket_name}/{s3_key}",
+                "s3_url": f"https://{self.bucket_name}.s3.amazonaws.com/{s3_key}",
                 "metadata": file_metadata,
                 "upload_result": upload_result
             }
@@ -190,7 +190,7 @@ class VoiceFileService:
                 return {
                     "success": True,
                     "s3_key": s3_key,
-                    "s3_url": f"s3://{self.bucket_name}/{s3_key}",
+                    "s3_url": f"https://{self.bucket_name}.s3.amazonaws.com/{s3_key}",
                     "metadata": file_metadata,
                     "upload_result": upload_result
                 }

--- a/backend/app/utils/constants.py
+++ b/backend/app/utils/constants.py
@@ -9,9 +9,9 @@ import os
 MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
 MAX_RECORDING_DURATION = 60       # 60秒
 
-# 利用制限
-MAX_DAILY_UPLOADS = 5             # 1日5回
-MAX_MONTHLY_UPLOADS = 100         # 1ヶ月100回
+# 利用制限 NOTE: 開発用に無効化
+# MAX_DAILY_UPLOADS = 5             # 1日5回
+# MAX_MONTHLY_UPLOADS = 100         # 1ヶ月100回
 
 # 音声品質設定
 AUDIO_QUALITY = {

--- a/frontend/src/app/(authed)/app/emotion-confirmation/page.tsx
+++ b/frontend/src/app/(authed)/app/emotion-confirmation/page.tsx
@@ -277,7 +277,7 @@ export default function EmotionConfirmationPage() {
     // 1秒後に次の画面に遷移
     setTimeout(() => {
       // 音声録音画面に遷移（完了後の遷移先を指定）
-      router.push(`/app/voice?emotion=${selectedEmotion?.id}&intensity=${selectedIntensity?.level}&child=${selectedChild?.id}&redirect=/app/entries/today`);
+      router.push(`/app/voice?emotion=${selectedEmotion?.id}&intensity=${selectedIntensity?.level}&child=${selectedChild?.id}&redirect=/app/voice/complete`);
     }, 1000);
   };
 

--- a/frontend/src/app/(authed)/app/emotion-confirmation/page.tsx
+++ b/frontend/src/app/(authed)/app/emotion-confirmation/page.tsx
@@ -277,7 +277,7 @@ export default function EmotionConfirmationPage() {
     // 1秒後に次の画面に遷移
     setTimeout(() => {
       // TODO: 音声入力画面に遷移（後でれなさんの用意した画面とくっつける）
-      router.push(`/app/voice?emotion=${selectedEmotion?.id}&intensity=${selectedIntensity?.level}`);
+      router.push(`/app/voice?emotion=${selectedEmotion?.id}&intensity=${selectedIntensity?.level}&child=${selectedChild?.id}`);
     }, 1000);
   };
 

--- a/frontend/src/app/(authed)/app/emotion-confirmation/page.tsx
+++ b/frontend/src/app/(authed)/app/emotion-confirmation/page.tsx
@@ -276,8 +276,8 @@ export default function EmotionConfirmationPage() {
     
     // 1秒後に次の画面に遷移
     setTimeout(() => {
-      // TODO: 音声入力画面に遷移（後でれなさんの用意した画面とくっつける）
-      router.push(`/app/voice?emotion=${selectedEmotion?.id}&intensity=${selectedIntensity?.level}&child=${selectedChild?.id}`);
+      // 音声録音画面に遷移（完了後の遷移先を指定）
+      router.push(`/app/voice?emotion=${selectedEmotion?.id}&intensity=${selectedIntensity?.level}&child=${selectedChild?.id}&redirect=/app/entries/today`);
     }, 1000);
   };
 

--- a/frontend/src/app/(authed)/app/entries/today/page.tsx
+++ b/frontend/src/app/(authed)/app/entries/today/page.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useTodayEntry } from '@/hooks/useTodayEntry'
+import { useChildren } from '@/hooks/useChildren'
+import { useSubscription } from '@/hooks/useSubscription'
+import PrimaryButton from '@/components/ui/PrimaryButton'
+import Spinner from '@/components/ui/Spinner'
+
+export default function TodayEntryPage() {
+  const router = useRouter()
+  const { todayEntry, isLoading } = useTodayEntry()
+  const { loading: childrenLoading } = useChildren()
+  const { loading: subscriptionLoading } = useSubscription()
+
+  const [isUpdating, setIsUpdating] = useState(false)
+
+  // 今日の日付を取得
+  const today = new Date().toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'long'
+  })
+
+  // 記録の存在確認
+  const hasEntry = !!todayEntry
+
+  // 更新処理
+  const handleUpdate = async () => {
+    setIsUpdating(true)
+    try {
+      // 感情選択画面から開始
+      router.push('/app/emotion-selection')
+    } catch (error) {
+      console.error('更新処理でエラーが発生しました:', error)
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  // ローディング状態
+  if (isLoading || childrenLoading || subscriptionLoading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
+        <div className="text-center">
+          <Spinner size="large" />
+          <p className="mt-4 text-gray-600">データを読み込み中...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+      {/* ヘッダー */}
+      <div className="bg-white shadow-sm border-b">
+        <div className="max-w-4xl mx-auto px-4 py-6">
+          <h1 className="text-3xl font-bold text-gray-800 mb-2">今日の記録</h1>
+          <p className="text-lg text-gray-600">{today}</p>
+        </div>
+      </div>
+
+      {/* メインコンテンツ */}
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        {/* ステータス表示 */}
+        <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-800 mb-2">
+                記録の状態
+              </h2>
+              <div className="flex items-center space-x-3">
+                <div className={`w-4 h-4 rounded-full ${hasEntry ? 'bg-green-500' : 'bg-gray-300'}`}></div>
+                <span className="text-gray-700">
+                  {hasEntry ? '今日の記録があります' : '今日の記録はありません'}
+                </span>
+              </div>
+            </div>
+            <div className="text-right">
+              <p className="text-sm text-gray-500">1日1件の制約</p>
+              <p className="text-xs text-gray-400">重複記録は自動的に更新されます</p>
+            </div>
+          </div>
+        </div>
+
+        {/* 記録がある場合 */}
+        {hasEntry && (
+          <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+            <h2 className="text-xl font-semibold text-gray-800 mb-4">既存の記録</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  感情
+                </label>
+                <p className="text-gray-900">{todayEntry.emotion}</p>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  感情強度
+                </label>
+                <p className="text-gray-900">{todayEntry.intensity}</p>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  作成日時
+                </label>
+                <p className="text-gray-900">
+                  {new Date(todayEntry.createdAt).toLocaleString('ja-JP')}
+                </p>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  記録日
+                </label>
+                <p className="text-gray-900">
+                  {new Date(todayEntry.date).toLocaleDateString('ja-JP')}
+                </p>
+              </div>
+            </div>
+            {todayEntry.transcript && (
+              <div className="mb-6">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  記録内容
+                </label>
+                <p className="text-gray-900 bg-gray-50 p-3 rounded-lg">
+                  {todayEntry.transcript}
+                </p>
+              </div>
+            )}
+            <div className="flex space-x-4">
+              <PrimaryButton onClick={handleUpdate} disabled={isUpdating}>
+                {isUpdating ? '更新中...' : '記録を更新'}
+              </PrimaryButton>
+              <button
+                onClick={() => router.push('/app/emotion-selection')}
+                className="px-6 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors"
+              >
+                感情選択ページへ
+              </button>
+            </div>
+          </div>
+        )}
+        {/* 1日1件制約の説明は削除 */}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/(authed)/app/voice/complete/page.tsx
+++ b/frontend/src/app/(authed)/app/voice/complete/page.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import { AudioPlayer } from '@/components/ui';
+import { commonStyles } from '@/styles/theme';
+
+export default function VoiceCompletePage() {
+  const router = useRouter();
+
+  // もどるボタンの処理
+  const handleBack = () => {
+    router.back();
+  };
+
+  return (
+    <div style={commonStyles.page.container}>
+      {/* 音声再生 */}
+      <AudioPlayer 
+        src="/sounds/characterThankYou05.mp3"
+        autoPlay={true}
+        volume={0.8}
+        onEnded={() => console.log('[AUDIO] 入力完了音声再生完了')}
+        onError={(error) => console.log('[AUDIO] 音声エラー:', error)}
+      />
+      
+      {/* 左上のもどるボタン */}
+      <button onClick={handleBack} style={{
+        position: 'fixed',
+        top: '20px',
+        left: '20px',
+        background: 'none',
+        border: 'none',
+        fontSize: '16px',
+        cursor: 'pointer',
+        padding: '6px',
+        borderRadius: '6px',
+        color: '#000000',
+        zIndex: 200,
+        fontWeight: 'bold',
+      }}>
+        ← もどる
+      </button>
+
+      {/* メインコンテンツ */}
+      <div style={{
+        position: 'fixed',
+        top: '0',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        bottom: 0,
+        padding: '10px 0 0 0',
+        zIndex: 50,
+        boxSizing: 'border-box',
+        width: '100%',
+        maxWidth: '600px',
+        overflowX: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        backdropFilter: 'blur(10px)',
+        background: 'transparent',
+        gap: '20px',
+      }}>
+        {/* こころんキャラクター */}
+        <div style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          marginBottom: '20px',
+        }}>
+          <Image
+            src="/images/kokoron/kokoron_thanks.webp"
+            alt="感謝のこころん"
+            width={450}
+            height={450}
+            priority={true}
+            style={{
+              objectFit: 'contain',
+            }}
+          />
+        </div>
+
+        {/* 完了メッセージ */}
+        <div style={{
+          background: '#ffffff',
+          borderRadius: '16px',
+          padding: '24px 32px',
+          boxShadow: '0 6px 16px rgba(0, 0, 0, 0.15)',
+          textAlign: 'center',
+          maxWidth: '400px',
+        }}>
+          <h1 style={{
+            fontSize: '28px',
+            fontWeight: 'bold',
+            color: '#333',
+            margin: '0 0 16px 0',
+            lineHeight: 1.3,
+          }}>
+            おしえてくれてありがとう♡
+          </h1>
+          <p style={{
+            fontSize: '18px',
+            color: '#666',
+            margin: 0,
+            lineHeight: 1.4,
+          }}>
+            きょうのきもちをきろくできました
+          </p>
+          
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(authed)/app/voice/page.tsx
+++ b/frontend/src/app/(authed)/app/voice/page.tsx
@@ -28,7 +28,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || '';
 
 // 待ち時間の応援メッセージ（ランダム切替）
 const WAIT_MESSAGES = [
-  'すごい！ いま ことばを ひろってるよ 🌟',
+  'すごい！ いま ことばを ひろってるよ ✨',
   'もうちょっと… おんぷを あつめてるよ 🎵',
   'こころん かんがえ中… 3, 2, 1… 🤔',
   'ピカーン！ ひらめき まちだよ ✨',
@@ -518,7 +518,7 @@ export default function VoiceEntryPage() {
         body: audioBlob,
       });
       if (!put.ok) throw new Error(`S3アップロード失敗: ${put.status} ${await put.text()}`);
-
+      
       const tr = await fetch(`${API_BASE}/api/v1/voice/transcribe`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -531,25 +531,32 @@ export default function VoiceEntryPage() {
       if (!tr.ok) throw new Error(`音声認識失敗: ${tr.status} ${await tr.text()}`);
       const trData: TranscriptionResult = await tr.json();
       setTranscription(trData);
+      // 追加：音声→テキストのパス生成＆テキスト本文
+      const audioPath = upData.file_path;
+      const textPath = audioPath.replace('.webm', '.txt');
 
       const save = await fetch(`${API_BASE}/api/v1/voice/save-record`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           user_id: user.id,
-          audio_file_path: upData.file_path,
-          text_file_path: null,
-          voice_note: transcription?.text || '', // ← 文字起こし結果追加
+          audio_file_path: audioPath,
+          text_file_path: textPath,     // null から upData.file_path に変更
+          // voice_note: transcription?.text || '', TODO: 音声認識テキストはDBに保存しない
           emotion_card_id: emotionId,
           intensity_id: intensityLevel,
-          child_id: childId, // ← 動的に取得した値を使用
+          child_id: childId,
         }),
       });
 
       if (!save.ok) throw new Error(`記録保存失敗: ${save.status} ${await save.text()}`);
 
       setStatus('できた！');
-      setTimeout(() => router.replace('/app/entries/today'), 600);
+
+      // 画面遷移処理
+      const redirectTo = searchParams.get('redirect') || '/app/voice/complete';
+      setTimeout(() => router.replace(redirectTo), 100);
+
     } catch (e: any) {
       console.error('[ERROR] upload/save', e);
       setError(e?.message || 'エラーが発生しました');

--- a/frontend/src/app/(authed)/app/voice/page.tsx
+++ b/frontend/src/app/(authed)/app/voice/page.tsx
@@ -42,6 +42,7 @@ export default function VoiceEntryPage() {
   const searchParams = useSearchParams();
   const emotionId = searchParams.get('emotion');
   const intensityLevel = searchParams.get('intensity');
+  const childId = searchParams.get('child');
 
   useEffect(() => {
     console.log('[EMOTION]', { emotionId, intensityLevel });
@@ -486,7 +487,7 @@ export default function VoiceEntryPage() {
   // --- アップロード＆保存 ---
   const uploadAndSave = async () => {
     if (!audioBlob || !user) return;
-    if (!emotionId || !intensityLevel) {
+    if (!emotionId || !intensityLevel || !childId) {
       setError('感情データが不足しています。感情選択画面から再度お試しください。');
       return;
     }
@@ -538,11 +539,13 @@ export default function VoiceEntryPage() {
           user_id: user.id,
           audio_file_path: upData.file_path,
           text_file_path: null,
+          voice_note: transcription?.text || '', // ← 文字起こし結果追加
           emotion_card_id: emotionId,
           intensity_id: intensityLevel,
-          child_id: '41489976-63ee-4332-85f4-6d9200a79bfc',
+          child_id: childId, // ← 動的に取得した値を使用
         }),
       });
+
       if (!save.ok) throw new Error(`記録保存失敗: ${save.status} ${await save.text()}`);
 
       setStatus('できた！');

--- a/frontend/src/app/(authed)/app/voice/page.tsx
+++ b/frontend/src/app/(authed)/app/voice/page.tsx
@@ -38,9 +38,9 @@ export default function VoiceEntryPage() {
 
   // ログ出力を追加
   useEffect(() => {
-    console.log('🎯 音声録音: 感情データ確認');
-    console.log('�� 音声録音: emotionId:', emotionId);
-    console.log('🎤 音声録音: intensityLevel:', intensityLevel);
+    console.log('[EMOTION] 音声録音: 感情データ確認');
+    console.log('[EMOTION] 音声録音: emotionId:', emotionId);
+    console.log('[EMOTION] 音声録音: intensityLevel:', intensityLevel);
   }, [emotionId, intensityLevel]);
 
   // 以降はログイン済み向けの処理
@@ -115,7 +115,7 @@ export default function VoiceEntryPage() {
   // --- 録音開始 ---
   const startRecording = async () => {
     try {
-      console.log('🎤 録音開始: 処理開始');
+      console.log('[RECORDING] 録音開始: 処理開始');
       setError(null);
       setStatus('マイク起動中…');
       setAudioBlob(null);
@@ -137,12 +137,12 @@ export default function VoiceEntryPage() {
         setStatus('録音完了。アップロードできます。');
       };
 
-      console.log('🎤 録音開始: マイク起動成功');
+      console.log('[RECORDING] 録音開始: マイク起動成功');
       rec.start();
       setIsRecording(true);
       setStatus('録音中…');
     } catch (err: any) {
-      console.error('🎤 録音開始: エラー発生', err);
+      console.error('[RECORDING] 録音開始: エラー発生', err);
       stopStream();
       setError(getErrorMessage(err));
       setStatus('録音できませんでした');
@@ -172,14 +172,14 @@ export default function VoiceEntryPage() {
     if (!audioBlob) return;
     if (!user) return;
 
-    console.log('�� アップロード保存: 処理開始');
-    console.log('🎤 アップロード保存: 感情データ確認');
-    console.log('🎤 アップロード保存: emotionId:', emotionId);
-    console.log('🎤 アップロード保存: intensityLevel:', intensityLevel);
+    console.log('[UPLOAD] アップロード保存: 処理開始');
+    console.log('[EMOTION] アップロード保存: 感情データ確認');
+    console.log('[EMOTION] アップロード保存: emotionId:', emotionId);
+    console.log('[EMOTION] アップロード保存: intensityLevel:', intensityLevel);
 
     // 感情データの確認
     if (!emotionId || !intensityLevel) {
-      console.error('🎤 アップロード保存: 感情データ不足');
+      console.error('[EMOTION] アップロード保存: 感情データ不足');
       setError('感情データが不足しています。感情選択画面から再度お試しください。');
       return;
     }
@@ -190,13 +190,13 @@ export default function VoiceEntryPage() {
 
     try {
       // 1) ヘルスチェック
-      console.log('🎤 アップロード保存: ヘルスチェック開始');
+      console.log('[HEALTH] アップロード保存: ヘルスチェック開始');
       const health = await fetch(`${API_BASE}/api/v1/voice/health`);
       if (!health.ok) throw new Error(`ヘルスチェック失敗: ${health.status}`);
-      console.log('🎤 アップロード保存: ヘルスチェック成功');
+      console.log('[HEALTH] アップロード保存: ヘルスチェック成功');
 
       // 2) PUT用URL取得
-      console.log('�� アップロード保存: S3アップロードURL取得開始');
+      console.log('[S3] アップロード保存: S3アップロードURL取得開始');
       setStatus('S3アップロード用URLを取得中…');
       const upRes = await fetch(`${API_BASE}/api/v1/voice/get-upload-url`, {
         method: 'POST',
@@ -209,10 +209,10 @@ export default function VoiceEntryPage() {
       });
       if (!upRes.ok) throw new Error(`アップロードURL取得失敗: ${upRes.status} ${await upRes.text()}`);
       const upData: GetUploadUrlResponse = await upRes.json();
-      console.log('�� アップロード保存: S3アップロードURL取得成功:', upData.file_path);
+      console.log('[S3] アップロード保存: S3アップロードURL取得成功:', upData.file_path);
 
       // 3) S3 に PUT
-      console.log('�� アップロード保存: S3アップロード開始');
+      console.log('[S3] アップロード保存: S3アップロード開始');
       setStatus('S3へアップロード中…');
       const put = await fetch(upData.upload_url, {
         method: 'PUT',
@@ -220,10 +220,10 @@ export default function VoiceEntryPage() {
         body: audioBlob,
       });
       if (!put.ok) throw new Error(`S3アップロード失敗: ${put.status} ${await put.text()}`);
-      console.log('�� アップロード保存: S3アップロード成功');
+      console.log('[S3] アップロード保存: S3アップロード成功');
 
       // 4) Whisper 文字起こし
-      console.log('🎤 アップロード保存: 音声認識開始');
+      console.log('[TRANSCRIPTION] アップロード保存: 音声認識開始');
       setStatus('音声を文字に変換中…');
       const tr = await fetch(`${API_BASE}/api/v1/voice/transcribe`, {
         method: 'POST',
@@ -238,10 +238,10 @@ export default function VoiceEntryPage() {
       if (!tr.ok) throw new Error(`音声認識失敗: ${tr.status} ${await tr.text()}`);
       const trData: TranscriptionResult = await tr.json();
       setTranscription(trData);
-      console.log('🎤 アップロード保存: 音声認識成功:', trData.text);
+      console.log('[TRANSCRIPTION] アップロード保存: 音声認識成功:', trData.text);
 
       // 5) DB に key を保存（感情データ付き）
-      console.log('�� アップロード保存: データベース保存開始');
+      console.log('[DATABASE] アップロード保存: データベース保存開始');
       setStatus('記録を保存中…');
       const save = await fetch(`${API_BASE}/api/v1/voice/save-record`, {
         method: 'POST',
@@ -257,12 +257,12 @@ export default function VoiceEntryPage() {
         }),
       });
       if (!save.ok) throw new Error(`記録保存失敗: ${save.status} ${await save.text()}`);
-      console.log('�� アップロード保存: データベース保存成功');
+      console.log('[DATABASE] アップロード保存: データベース保存成功');
 
       setStatus('保存完了！「きょうの記録」に移動します…');
       setTimeout(() => router.replace('/app/entries/today'), 600);
     } catch (e: any) {
-      console.error('🎤 アップロード保存: エラー発生', e);
+      console.error('[ERROR] アップロード保存: エラー発生', e);
       setError(e?.message || '処理中にエラーが発生しました');
       setStatus('エラーが発生しました');
     } finally {
@@ -531,7 +531,7 @@ export default function VoiceEntryPage() {
                 fontSize: '24px',
                 fontWeight: 'bold',
               }}>
-                {isRecording ? '⏹ 停止' : '🎤 録音開始'}
+                {isRecording ? '[STOP] 停止' : '[RECORD] 録音開始'}
               </span>
             </div>
           </button>

--- a/frontend/src/app/(authed)/app/voice/page.tsx
+++ b/frontend/src/app/(authed)/app/voice/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { getAudioConstraints, selectRecorderConfig, getErrorMessage } from '@/utils/audio';
 import { colors, commonStyles, spacing, borderRadius } from '@/styles/theme';
+import { AudioPlayer } from '@/components/ui';
 
 type GetUploadUrlResponse = {
   success: boolean;
@@ -30,7 +31,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || '';
 const WAIT_MESSAGES = [
   'すごい！ いま ことばを ひろってるよ ✨',
   'もうちょっと… おんぷを あつめてるよ 🎵',
-  'こころん かんがえ中… 3, 2, 1… 🤔',
+  'こころん かんがえちゅう… 3, 2, 1… 🤔',
   'ピカーン！ ひらめき まちだよ ✨',
   'じょうずに はなせたね！ よみこみ中… ⏳',
 ];
@@ -650,6 +651,15 @@ export default function VoiceEntryPage() {
   // UI本体
   return (
     <div style={styles.page}>
+      {/* 音声自動再生 */}
+      <AudioPlayer 
+        src="/sounds/characterAskReason04.mp3"
+        autoPlay={true}
+        volume={0.8}
+        onEnded={() => console.log('[AUDIO] 感情確認音声再生完了')}
+        onError={(error) => console.log('[AUDIO] 音声エラー:', error)}
+      />
+
       {/* keyframes（CSS）をこの画面だけに注入 */}
       <style>{`
         @keyframes bob {

--- a/frontend/src/app/(authed)/app/voice/page.tsx
+++ b/frontend/src/app/(authed)/app/voice/page.tsx
@@ -4,14 +4,14 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { getAudioConstraints, selectRecorderConfig, getErrorMessage } from '@/utils/audio';
-import { colors, commonStyles, spacing, borderRadius, animation } from '@/styles/theme';
+import { colors, commonStyles, spacing, borderRadius } from '@/styles/theme';
 
 type GetUploadUrlResponse = {
   success: boolean;
-  upload_url: string;    // 署名付きPUT URL
-  file_path: string;     // ← DBに保存すべき「S3キー」
+  upload_url: string;
+  file_path: string;
   s3_url?: string;
-  content_type: string;  // 例: audio/webm
+  content_type: string;
 };
 
 type TranscriptionResult = {
@@ -26,24 +26,27 @@ type TranscriptionResult = {
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || '';
 
+// 待ち時間の応援メッセージ（ランダム切替）
+const WAIT_MESSAGES = [
+  'すごい！ いま ことばを ひろってるよ 🌟',
+  'もうちょっと… おんぷを あつめてるよ 🎵',
+  'こころん かんがえ中… 3, 2, 1… 🤔',
+  'ピカーン！ ひらめき まちだよ ✨',
+  'じょうずに はなせたね！ よみこみ中… ⏳',
+];
+
 export default function VoiceEntryPage() {
-  // 認証チェック
   const { user, isLoading } = useAuth();
   const router = useRouter();
-  
-  // URLパラメータから感情データを取得
+
   const searchParams = useSearchParams();
   const emotionId = searchParams.get('emotion');
   const intensityLevel = searchParams.get('intensity');
 
-  // ログ出力を追加
   useEffect(() => {
-    console.log('[EMOTION] 音声録音: 感情データ確認');
-    console.log('[EMOTION] 音声録音: emotionId:', emotionId);
-    console.log('[EMOTION] 音声録音: intensityLevel:', intensityLevel);
+    console.log('[EMOTION]', { emotionId, intensityLevel });
   }, [emotionId, intensityLevel]);
 
-  // 以降はログイン済み向けの処理
   const [checkingToday, setCheckingToday] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -59,14 +62,311 @@ export default function VoiceEntryPage() {
   const streamRef = useRef<MediaStream | null>(null);
   const recConfig = useMemo(() => selectRecorderConfig(), []);
 
-  // 認証前後の制御
+  // 再生
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  // 応援メッセージのインデックス
+  const [msgIndex, setMsgIndex] = useState(0);
+
+  const handleBack = () => router.push('/app/emotion-confirmation');
+
+  // ====== レイアウト ======
+  const LAYOUT = { maxWidth: 430, cardMaxWidth: 360 };
+  const styles = {
+    page: {
+      background: 'url("/images/background.webp") no-repeat center center',
+      backgroundSize: 'cover',
+      minHeight: '100dvh',
+      display: 'flex',
+      flexDirection: 'column' as const,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    panel: {
+      position: 'fixed' as const,
+      top: 0,
+      left: '50%',
+      transform: 'translateX(-50%)',
+      bottom: 0,
+      padding: 'max(10px, env(safe-area-inset-top)) 0 max(16px, env(safe-area-inset-bottom)) 0',
+      zIndex: 50,
+      boxSizing: 'border-box' as const,
+      width: 'min(100vw, 430px)',
+      maxWidth: `${LAYOUT.maxWidth}px`,
+      overflowX: 'hidden' as const,
+      display: 'flex',
+      flexDirection: 'column' as const,
+      justifyContent: 'flex-start',
+      alignItems: 'center',
+      gap: 12,
+      background: 'transparent',
+    },
+    backBtn: {
+      position: 'fixed' as const,
+      top: 20,
+      left: 20,
+      background: 'none',
+      border: 'none',
+      fontSize: 16,
+      cursor: 'pointer',
+      padding: 6,
+      borderRadius: 6,
+      color: '#000',
+      zIndex: 200,
+      fontWeight: 'bold' as const,
+    },
+    bubbleSmall: {
+      marginTop: 60,
+      background: '#fff',
+      borderRadius: 12,
+      padding: '8px 10px',
+      boxShadow: '0 4px 10px rgba(0,0,0,0.1)',
+      width: '88%',
+      maxWidth: `${Math.min(320, LAYOUT.maxWidth)}px`,
+      textAlign: 'center' as const,
+    },
+    bubbleTextSmall: { fontWeight: 700, fontSize: 14, lineHeight: 1.3, color: '#333' },
+
+    characterWrap: {
+      display: 'flex',
+      flexDirection: 'column' as const,
+      alignItems: 'center',
+      gap: 8,
+      marginTop: 10,
+      marginBottom: 10,
+    },
+    characterImg: {
+      width: 'min(70vw, 300px)',
+      height: 'min(70vw, 300px)',
+      objectFit: 'contain' as const,
+    },
+
+    // 録音セクション（白枠カード）
+    recordCard: {
+      marginTop: 8,
+      padding: 12,
+      borderRadius: 12,
+      border: '1px solid #e5e7eb',
+      background: '#fff',
+      boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+      width: '92%',
+      maxWidth: `${Math.min(LAYOUT.cardMaxWidth, LAYOUT.maxWidth)}px`,
+      textAlign: 'center' as const,
+    },
+    recordButtonWrap: {
+      marginTop: 4,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '100%',
+    },
+    recordOuter: {
+      width: 220,
+      height: 220,
+      borderRadius: '50%',
+      border: '8px solid #d1d5db',
+      background: '#ffffff',
+      display: 'grid',
+      placeItems: 'center',
+      boxShadow: '0 10px 24px rgba(0,0,0,0.18)',
+      userSelect: 'none' as const,
+      touchAction: 'manipulation' as const,
+      WebkitTapHighlightColor: 'transparent',
+      cursor: 'pointer',
+      transition: 'transform 0.12s ease',
+      position: 'relative' as const, // ⏸重ね表示のため
+    },
+    recordInnerIdle: {
+      width: 160,
+      height: 160,
+      borderRadius: '50%',
+      background: '#ef4444',
+    },
+    recordInnerActive: {
+      width: 170,
+      height: 170,
+      borderRadius: '50%',
+      background: '#ef4444',
+      boxShadow: '0 0 0 6px rgba(239,68,68,0.25)',
+    },
+    // 録音中の⏸表示（同じボタン内で重ねる）
+    pauseIconWrap: {
+      position: 'absolute' as const,
+      inset: 0,
+      display: 'grid',
+      placeItems: 'center',
+      pointerEvents: 'none' as const,
+    },
+    pauseBars: {
+      display: 'grid',
+      gridAutoFlow: 'column',
+      gap: 12,
+    },
+    pauseBar: {
+      width: 18,
+      height: 70,
+      borderRadius: 6,
+      background: '#ffffff',
+      boxShadow: '0 0 0 1px rgba(0,0,0,0.05) inset',
+    },
+    recordHelper: {
+      marginTop: 8,
+      fontWeight: 700,
+      color: '#111827',
+    },
+
+    // 「きいてみる」
+    confirmCard: {
+      marginTop: 16,
+      padding: 12,
+      borderRadius: 12,
+      border: '1px solid #e5e7eb',
+      background: '#fff',
+      boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+      width: '92%',
+      maxWidth: `${Math.min(LAYOUT.cardMaxWidth, LAYOUT.maxWidth)}px`,
+      textAlign: 'center' as const,
+    },
+    confirmTitle: { fontWeight: 700, marginBottom: 10, color: '#111827', fontSize: 18 },
+    playButtonBase: {
+      width: 200,
+      height: 200,
+      borderRadius: '50%',
+      display: 'grid',
+      placeItems: 'center',
+      fontSize: 72,
+      fontWeight: 900,
+      cursor: 'pointer',
+      margin: '12px auto',
+      boxShadow: '0 10px 24px rgba(0,0,0,0.2)',
+      userSelect: 'none' as const,
+      touchAction: 'manipulation' as const,
+      WebkitTapHighlightColor: 'transparent',
+      color: '#111827',
+      border: '8px solid transparent',
+    },
+    playButtonIdle: {
+      background: '#facc15',
+      borderColor: '#eab308',
+    },
+    playButtonActive: {
+      background: '#ef4444',
+      borderColor: '#b91c1c',
+      color: '#ffffff',
+    },
+
+    confirmButtons: {
+      display: 'grid',
+      gridTemplateColumns: '1fr 1fr',
+      gap: 10,
+      marginTop: 14,
+    },
+    btnPrimary: {
+      padding: '14px 16px',
+      borderRadius: 12,
+      background: '#10b981',
+      color: '#fff',
+      fontWeight: 800,
+      fontSize: 18,
+      border: 'none',
+      cursor: 'pointer',
+    },
+    btnDanger: {
+      padding: '14px 16px',
+      borderRadius: 12,
+      background: '#fca5a5',
+      color: '#7f1d1d',
+      fontWeight: 800,
+      fontSize: 18,
+      border: '2px solid #ef4444',
+      cursor: 'pointer',
+    },
+
+    statusCard: (hasError: boolean) => ({
+      marginTop: 8,
+      padding: 10,
+      borderRadius: 10,
+      border: `1px solid ${hasError ? '#f5c2c7' : '#e5e7eb'}`,
+      background: hasError ? '#fdecee' : '#fafafa',
+      color: hasError ? '#842029' : '#111827',
+      width: '92%',
+      maxWidth: `${Math.min(LAYOUT.cardMaxWidth, LAYOUT.maxWidth)}px`,
+      textAlign: 'center' as const,
+      fontSize: 14,
+    }),
+
+    // === 待ち時間の演出（オーバーレイ） ===
+    overlay: {
+      position: 'fixed' as const,
+      inset: 0,
+      background: 'rgba(0,0,0,0.2)',
+      backdropFilter: 'blur(1px)',
+      zIndex: 300,
+      display: 'grid',
+      placeItems: 'center',
+    },
+    waitCard: {
+      width: 'min(88vw, 360px)',
+      borderRadius: 16,
+      background: '#ffffff',
+      border: '1px solid #e5e7eb',
+      boxShadow: '0 12px 30px rgba(0,0,0,0.25)',
+      padding: 16,
+      textAlign: 'center' as const,
+    },
+    waitKokoron: {
+      width: 180,
+      height: 180,
+      objectFit: 'contain' as const,
+      animation: 'bob 1.6s ease-in-out infinite',
+      margin: '0 auto 8px',
+    },
+    waitBubble: {
+      background: '#fff',
+      borderRadius: 12,
+      border: '1px solid #e5e7eb',
+      padding: '8px 10px',
+      margin: '0 auto 8px',
+      fontWeight: 800,
+      color: '#111827',
+      width: '92%',
+    },
+    progressWrap: {
+      width: '92%',
+      height: 10,
+      borderRadius: 999,
+      background: '#f3f4f6',
+      overflow: 'hidden' as const,
+      margin: '6px auto 2px',
+      border: '1px solid #e5e7eb',
+    },
+    progressBar: {
+      width: '40%',
+      height: '100%',
+      borderRadius: 999,
+      background: 'linear-gradient(90deg, #fde68a, #facc15, #f59e0b)',
+      animation: 'indet 1.2s infinite',
+    },
+    waitHint: { fontSize: 12, color: '#6b7280', marginTop: 6 },
+  } as const;
+  // ====== ここまで ======
+
+  // 応援メッセージ切替（isBusyの間だけ）
   useEffect(() => {
-    if (!isLoading && !user) {
-      router.replace('/');
-    }
+    if (!isBusy) return;
+    const id = setInterval(() => {
+      setMsgIndex((i) => (i + 1) % WAIT_MESSAGES.length);
+    }, 1500);
+    return () => clearInterval(id);
+  }, [isBusy]);
+
+  // 認証チェック
+  useEffect(() => {
+    if (!isLoading && !user) router.replace('/');
   }, [isLoading, user, router]);
 
-  // 今日の記録有無チェック → あれば edit へ
+  // 今日の記録チェック
   useEffect(() => {
     const checkToday = async () => {
       if (!user) return;
@@ -87,11 +387,7 @@ export default function VoiceEntryPage() {
         const ymd = `${y}${m}${d}`;
 
         const hasToday = (data?.records ?? []).some((r: any) => {
-          // backend は created_at を ["YYYYMMDD","HHMMSS"] で返す想定
-          if (Array.isArray(r?.created_at) && r.created_at[0]) {
-            return r.created_at[0] === ymd;
-          }
-          // フォールバック: ファイル名から抽出
+          if (Array.isArray(r?.created_at) && r.created_at[0]) return r.created_at[0] === ymd;
           const name = String(r?.audio_path || '');
           const m2 = name.match(/audio_(\d{8})_/);
           return m2?.[1] === ymd;
@@ -102,24 +398,22 @@ export default function VoiceEntryPage() {
           return;
         }
       } catch (e: any) {
-        // 失敗しても録音UIにフォールバック
         setError(e?.message || '今日の記録確認に失敗しました');
       } finally {
         setCheckingToday(false);
       }
     };
-
     if (user) checkToday();
   }, [user, router]);
 
   // --- 録音開始 ---
   const startRecording = async () => {
     try {
-      console.log('[RECORDING] 録音開始: 処理開始');
       setError(null);
-      setStatus('マイク起動中…');
+      setStatus('');
       setAudioBlob(null);
       setTranscription(null);
+      setIsPlaying(false);
 
       const stream = await navigator.mediaDevices.getUserMedia(getAudioConstraints());
       streamRef.current = stream;
@@ -134,18 +428,16 @@ export default function VoiceEntryPage() {
         const blob = new Blob(chunksRef.current, { type: recConfig.contentType });
         setAudioBlob(blob);
         stopStream();
-        setStatus('録音完了。アップロードできます。');
+        setStatus('');
       };
 
-      console.log('[RECORDING] 録音開始: マイク起動成功');
       rec.start();
       setIsRecording(true);
-      setStatus('録音中…');
     } catch (err: any) {
-      console.error('[RECORDING] 録音開始: エラー発生', err);
+      console.error('[RECORDING] error', err);
       stopStream();
       setError(getErrorMessage(err));
-      setStatus('録音できませんでした');
+      setStatus('エラーが発生しました');
       setIsRecording(false);
     }
   };
@@ -167,68 +459,68 @@ export default function VoiceEntryPage() {
     streamRef.current = null;
   };
 
-  // --- S3アップロード → Whisper → DB保存 ---
+  // 再生（▶/⏸切替）
+  const togglePlay = async () => {
+    if (!audioRef.current) return;
+    try {
+      if (audioRef.current.paused) {
+        await audioRef.current.play();
+        setIsPlaying(true);
+      } else {
+        audioRef.current.pause();
+        setIsPlaying(false);
+      }
+    } catch (e) {
+      console.error('playback error', e);
+    }
+  };
+
+  useEffect(() => {
+    const a = audioRef.current;
+    if (!a) return;
+    const onEnded = () => setIsPlaying(false);
+    a.addEventListener('ended', onEnded);
+    return () => a.removeEventListener('ended', onEnded);
+  }, [audioBlob]);
+
+  // --- アップロード＆保存 ---
   const uploadAndSave = async () => {
-    if (!audioBlob) return;
-    if (!user) return;
-
-    console.log('[UPLOAD] アップロード保存: 処理開始');
-    console.log('[EMOTION] アップロード保存: 感情データ確認');
-    console.log('[EMOTION] アップロード保存: emotionId:', emotionId);
-    console.log('[EMOTION] アップロード保存: intensityLevel:', intensityLevel);
-
-    // 感情データの確認
+    if (!audioBlob || !user) return;
     if (!emotionId || !intensityLevel) {
-      console.error('[EMOTION] アップロード保存: 感情データ不足');
       setError('感情データが不足しています。感情選択画面から再度お試しください。');
       return;
     }
 
     setIsBusy(true);
     setError(null);
-    setStatus('API接続確認中…');
+    setStatus('すこしまってね…');
 
     try {
-      // 1) ヘルスチェック
-      console.log('[HEALTH] アップロード保存: ヘルスチェック開始');
       const health = await fetch(`${API_BASE}/api/v1/voice/health`);
       if (!health.ok) throw new Error(`ヘルスチェック失敗: ${health.status}`);
-      console.log('[HEALTH] アップロード保存: ヘルスチェック成功');
 
-      // 2) PUT用URL取得
-      console.log('[S3] アップロード保存: S3アップロードURL取得開始');
-      setStatus('S3アップロード用URLを取得中…');
       const upRes = await fetch(`${API_BASE}/api/v1/voice/get-upload-url`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           user_id: user.id,
           file_type: 'audio',
-          file_format: recConfig.ext, // 'webm' を送る
+          file_format: recConfig.ext,
         }),
       });
       if (!upRes.ok) throw new Error(`アップロードURL取得失敗: ${upRes.status} ${await upRes.text()}`);
       const upData: GetUploadUrlResponse = await upRes.json();
-      console.log('[S3] アップロード保存: S3アップロードURL取得成功:', upData.file_path);
 
-      // 3) S3 に PUT
-      console.log('[S3] アップロード保存: S3アップロード開始');
-      setStatus('S3へアップロード中…');
       const put = await fetch(upData.upload_url, {
         method: 'PUT',
         headers: { 'Content-Type': upData.content_type },
         body: audioBlob,
       });
       if (!put.ok) throw new Error(`S3アップロード失敗: ${put.status} ${await put.text()}`);
-      console.log('[S3] アップロード保存: S3アップロード成功');
 
-      // 4) Whisper 文字起こし
-      console.log('[TRANSCRIPTION] アップロード保存: 音声認識開始');
-      setStatus('音声を文字に変換中…');
       const tr = await fetch(`${API_BASE}/api/v1/voice/transcribe`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        // ← backendは「S3キー」も受け付けるので、key をそのまま送る
         body: JSON.stringify({
           user_id: user.id,
           audio_file_path: upData.file_path,
@@ -238,67 +530,48 @@ export default function VoiceEntryPage() {
       if (!tr.ok) throw new Error(`音声認識失敗: ${tr.status} ${await tr.text()}`);
       const trData: TranscriptionResult = await tr.json();
       setTranscription(trData);
-      console.log('[TRANSCRIPTION] アップロード保存: 音声認識成功:', trData.text);
 
-      // 5) DB に key を保存（感情データ付き）
-      console.log('[DATABASE] アップロード保存: データベース保存開始');
-      setStatus('記録を保存中…');
       const save = await fetch(`${API_BASE}/api/v1/voice/save-record`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           user_id: user.id,
           audio_file_path: upData.file_path,
-          text_file_path: null, // 将来: テキストもS3に保存したらここに key を入れる
-          // 感情データを追加
+          text_file_path: null,
           emotion_card_id: emotionId,
           intensity_id: intensityLevel,
-          child_id: '41489976-63ee-4332-85f4-6d9200a79bfc', // 作成した子供のID
+          child_id: '41489976-63ee-4332-85f4-6d9200a79bfc',
         }),
       });
       if (!save.ok) throw new Error(`記録保存失敗: ${save.status} ${await save.text()}`);
-      console.log('[DATABASE] アップロード保存: データベース保存成功');
 
-      setStatus('保存完了！「きょうの記録」に移動します…');
+      setStatus('できた！');
       setTimeout(() => router.replace('/app/entries/today'), 600);
     } catch (e: any) {
-      console.error('[ERROR] アップロード保存: エラー発生', e);
-      setError(e?.message || '処理中にエラーが発生しました');
+      console.error('[ERROR] upload/save', e);
+      setError(e?.message || 'エラーが発生しました');
       setStatus('エラーが発生しました');
     } finally {
       setIsBusy(false);
     }
   };
 
-  // 認証判定中 or 未ログインでリダイレクト待ち
+  // ローディング系
   if (isLoading || !user) {
     return (
-      <main style={{
-        display: 'grid',
-        placeItems: 'center',
-        minHeight: '60vh',
-        color: colors.text.secondary,
-      }}>
+      <main style={{ display: 'grid', placeItems: 'center', minHeight: '60vh', color: colors.text.secondary }}>
         <p>読み込み中...</p>
       </main>
     );
   }
-
-  // 今日の記録チェック中（ある場合はこの後 edit へリダイレクト）
   if (checkingToday) {
     return (
-      <main style={{
-        display: 'grid',
-        placeItems: 'center',
-        minHeight: '60vh',
-        color: colors.text.secondary,
-      }}>
+      <main style={{ display: 'grid', placeItems: 'center', minHeight: '60vh', color: colors.text.secondary }}>
         <p>きょうの記録を確認中…</p>
       </main>
     );
   }
 
-  // 感情データが不足している場合
   if (!emotionId || !intensityLevel) {
     return (
       <main style={{
@@ -309,18 +582,10 @@ export default function VoiceEntryPage() {
         backgroundSize: 'cover',
         minHeight: '100vh',
       }}>
-        <h1 style={{
-          fontSize: '22px',
-          fontWeight: 700,
-          marginBottom: spacing.sm,
-          color: colors.text.primary,
-        }}>
+        <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: spacing.sm, color: colors.text.primary }}>
           感情データが不足しています
         </h1>
-        <p style={{
-          marginBottom: spacing.md,
-          color: colors.text.secondary,
-        }}>
+        <p style={{ marginBottom: spacing.md, color: colors.text.secondary }}>
           感情選択画面から再度お試しください。
         </p>
         <button
@@ -341,373 +606,149 @@ export default function VoiceEntryPage() {
     );
   }
 
-  // 録音UI
+  // UI本体
   return (
-    // 背景全体をカバーするラッパー
-    <div style={{
-      background: 'url("/images/background.webp") no-repeat center center',
-      backgroundSize: 'cover',
-      minHeight: '100vh',
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-    }}>
-      <main style={{
-        position: 'fixed',
-        top: '0',
-        left: '50%',
-        transform: 'translateX(-50%)',
-        bottom: 0,
-        padding: '10px 0 0 0',
-        zIndex: 50,
-        boxSizing: 'border-box',
-        width: '100%',
-        maxWidth: '600px',
-        overflowX: 'hidden',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'center',
-        backdropFilter: 'blur(10px)',
-        background: 'transparent',
-        gap: '8px',
-      }}>
+    <div style={styles.page}>
+      {/* keyframes（CSS）をこの画面だけに注入 */}
+      <style>{`
+        @keyframes bob {
+          0%,100% { transform: translateY(0); }
+          50% { transform: translateY(-8px); }
+        }
+        @keyframes indet {
+          0% { transform: translateX(-60%); }
+          100% { transform: translateX(160%); }
+        }
+      `}</style>
 
-        {/* こころんキャラクター */}
-        <div style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '16px',
-          marginBottom: '20px',
-          marginTop: '20px',
-        }}>
-          <img
-            src="/images/kokoron/kokoron_mic.webp"
-            alt="マイクを持つこころん"
-            style={{
-              width: '250px',
-              height: '250px',
-              objectFit: 'contain',
-            }}
-          />
+      <main style={styles.panel} aria-busy={isBusy}>
+        <button onClick={handleBack} style={styles.backBtn} disabled={isBusy}>← もどる</button>
+
+        {/* バブル */}
+        <div style={styles.bubbleSmall}>
+          <span style={styles.bubbleTextSmall}>どうしてこのきもちになったのかな？</span>
         </div>
 
-        {/* 白枠の囲い（こころんおしゃべりコメント） */}
-        <div style={{
-          background: '#ffffff',
-          borderRadius: '16px',
-          padding: '16px 20px',
-          boxShadow: '0 6px 16px rgba(0, 0, 0, 0.15)',
-          width: '80%',
-          maxWidth: '320px',
-          boxSizing: 'border-box',
-          textAlign: 'center',
-          marginBottom: '20px',
-        }}>
-          <div style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '8px',
-            alignItems: 'center',
-          }}>
-            <span style={{
-              fontWeight: 'bold',
-              fontSize: '24px',
-              lineHeight: 1.2,
-              margin: 0,
-              color: '#333',
-            }}>
-              どうしてそのきもちになったのかな？
-            </span>
-          </div>
+        {/* キャラクター */}
+        <div style={styles.characterWrap}>
+          <img src="/images/kokoron/kokoron_mic.webp" alt="マイクを持つこころん" style={styles.characterImg} />
         </div>
 
-        {/* 感情データの表示 */}
-        <div style={{
-          marginBottom: spacing.md,
-          padding: spacing.md,
-          borderRadius: borderRadius.medium,
-          border: `1px solid ${colors.border.light}`,
-          background: colors.background.white,
-          boxShadow: colors.shadow.light,
-          width: '100%',
-          maxWidth: '320px',
-          textAlign: 'center',
-        }}>
-          <div style={{
-            fontWeight: 700,
-            marginBottom: spacing.xs,
-            color: colors.text.primary,
-          }}>
-            選択された感情
-          </div>
-          <div style={{
-            fontSize: '14px',
-            color: colors.text.secondary,
-          }}>
-            感情ID: {emotionId} / 強度: {intensityLevel}
-          </div>
-        </div>
+        {/* 録音（白枠カード＋1ボタン切替） */}
+        {!audioBlob && (
+          <section style={styles.recordCard}>
+            <div style={styles.recordButtonWrap}>
+              <button
+                onClick={isRecording ? stopRecording : startRecording}
+                aria-label={isRecording ? '録音をとめる' : '録音をはじめる'}
+                disabled={isBusy}
+                style={styles.recordOuter}
+              >
+                <div style={isRecording ? styles.recordInnerActive : styles.recordInnerIdle} />
+                {isRecording && (
+                  <div style={styles.pauseIconWrap} aria-hidden="true">
+                    <div style={styles.pauseBars}>
+                      <div style={styles.pauseBar} />
+                      <div style={styles.pauseBar} />
+                    </div>
+                  </div>
+                )}
+              </button>
+            </div>
+            <div style={styles.recordHelper}>{isRecording ? 'とめる' : 'はなしてね'}</div>
+          </section>
+        )}
 
-        {/* ステータス */}
+        {/* 確認パネル（録音後） */}
+        {audioBlob && !isRecording && (
+          <section style={styles.confirmCard} aria-live="polite">
+            <div style={styles.confirmTitle}>きいてみる</div>
+
+            <button
+              onClick={togglePlay}
+              style={{
+                ...styles.playButtonBase,
+                ...(isPlaying ? styles.playButtonActive : styles.playButtonIdle),
+              }}
+              disabled={isBusy}
+              aria-label={isPlaying ? 'とめる' : 'きく'}
+            >
+              <span>{isPlaying ? '⏸' : '▶'}</span>
+            </button>
+
+            {/* 隠しaudio */}
+            <audio
+              ref={audioRef}
+              src={audioBlob ? URL.createObjectURL(audioBlob) : undefined}
+              style={{ display: 'none' }}
+            />
+
+            <div style={styles.confirmButtons}>
+              <button style={styles.btnPrimary} onClick={uploadAndSave} disabled={isBusy}>
+                ✅ いい
+              </button>
+              <button
+                style={styles.btnDanger}
+                onClick={startRecording}
+                disabled={isBusy}
+              >
+                🔴 もういっかい
+              </button>
+            </div>
+          </section>
+        )}
+
         {(status || error) && (
-          <div
-            style={{
-              margin: `${spacing.md} 0`,
-              padding: spacing.md,
-              borderRadius: borderRadius.medium,
-              border: `1px solid ${error ? '#f5c2c7' : colors.border.light}`,
-              background: error ? '#fdecee' : '#fafafa',
-              color: error ? '#842029' : colors.text.primary,
-              width: '100%',
-              maxWidth: '320px',
-              textAlign: 'center',
-            }}
-          >
-            <div style={{ fontWeight: 600 }}>{status}</div>
-            {error && <div style={{ marginTop: spacing.xs }}>{error}</div>}
+          <div style={styles.statusCard(!!error)}>
+            <div style={{ fontWeight: 700 }}>{status}</div>
+            {error && <div style={{ marginTop: 6 }}>{error}</div>}
           </div>
         )}
 
-        {/* ボタンコンテナ */}
-        <div style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '19px',
-          width: '100%',
-          maxWidth: '320px',
-          justifyContent: 'center',
-          alignItems: 'center',
-          marginBottom: '20px',
-        }}>
-          {/* 録音ボタン */}
-          <button
-            onClick={isRecording ? stopRecording : startRecording}
-            disabled={isBusy}
-            style={{
-              background: '#ffffff',
-              border: `8px solid ${isRecording ? '#ffb3b3' : colors.primary}`,
-              borderRadius: '12px',
-              padding: '16px 12px',
-              cursor: isBusy ? 'not-allowed' : 'pointer',
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              gap: '8px',
-              transition: 'all 0.3s ease',
-              fontSize: '18px',
-              fontWeight: 'bold',
-              color: '#000000',
-              boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
-              minHeight: '100px',
-              justifyContent: 'center',
-              touchAction: 'manipulation',
-              WebkitTapHighlightColor: 'transparent',
-              width: '100%',
-              maxWidth: '100%',
-              boxSizing: 'border-box',
-              overflow: 'hidden',
-              position: 'relative',
-              ...(isBusy && {
-                backgroundColor: '#ccc',
-                cursor: 'not-allowed',
-                transform: 'none',
-                boxShadow: 'none',
-              }),
-            }}
-          >
-            <div style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: '100%',
-              height: '100%',
-              gap: '12px',
-            }}>
-              <span style={{
-                fontSize: '24px',
-                fontWeight: 'bold',
-              }}>
-                {isRecording ? '[STOP] 停止' : '[RECORD] 録音開始'}
-              </span>
-            </div>
-          </button>
-
-          {/* アップロード・保存ボタン */}
-          <button
-            onClick={uploadAndSave}
-            disabled={!audioBlob || isBusy}
-            style={{
-              background: '#ffffff',
-              border: `8px solid ${!audioBlob || isBusy ? '#ccc' : '#10b981'}`,
-              borderRadius: '12px',
-              padding: '8px 16px',
-              cursor: !audioBlob || isBusy ? 'not-allowed' : 'pointer',
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              gap: '8px',
-              transition: 'all 0.3s ease',
-              fontSize: '16px',
-              fontWeight: 'bold',
-              color: '#000000',
-              boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
-              minHeight: '60px',
-              justifyContent: 'center',
-              touchAction: 'manipulation',
-              WebkitTapHighlightColor: 'transparent',
-              width: '100%',
-              maxWidth: '100%',
-              boxSizing: 'border-box',
-              overflow: 'hidden',
-              position: 'relative',
-              ...((!audioBlob || isBusy) && {
-                backgroundColor: '#ccc',
-                cursor: 'not-allowed',
-                transform: 'none',
-                boxShadow: 'none',
-              }),
-            }}
-          >
-            <div style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: '100%',
-              height: '100%',
-              gap: '12px',
-            }}>
-              <span style={{
-                fontSize: '18px',
-                fontWeight: 'bold',
-              }}>
-                ⬆︎ アップロード → 保存
-              </span>
-            </div>
-          </button>
-
-          {/* 取り直すボタン（子供でも分かりやすい） */}
-          <button
-            onClick={() => {
-              setAudioBlob(null);
-              setTranscription(null);
-              setStatus('');
-              setError(null);
-            }}
-            disabled={isBusy}
-            style={{
-              background: '#ffffff',
-              border: `8px solid ${isBusy ? '#ccc' : colors.border.light}`,
-              borderRadius: '12px',
-              padding: '8px 16px',
-              cursor: isBusy ? 'not-allowed' : 'pointer',
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              gap: '8px',
-              transition: 'all 0.3s ease',
-              fontSize: '16px',
-              fontWeight: 'bold',
-              color: '#000000',
-              boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
-              minHeight: '60px',
-              justifyContent: 'center',
-              touchAction: 'manipulation',
-              WebkitTapHighlightColor: 'transparent',
-              width: '100%',
-              maxWidth: '100%',
-              boxSizing: 'border-box',
-              overflow: 'hidden',
-              position: 'relative',
-              ...(isBusy && {
-                cursor: 'not-allowed',
-                opacity: 0.6,
-              }),
-            }}
-          >
-            <div style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: '100%',
-              height: '100%',
-              gap: '12px',
-            }}>
-              <span style={{
-                fontSize: '18px',
-                fontWeight: 'bold',
-              }}>
-                もどる
-              </span>
-            </div>
-          </button>
-        </div>
-
-        {/* プレビュー */}
-        {audioBlob && (
-          <div style={{ 
-            marginTop: spacing.md,
-            width: '100%',
-            maxWidth: '320px',
-            textAlign: 'center',
-          }}>
-            <audio controls src={URL.createObjectURL(audioBlob)} style={{ width: '100%' }} />
-            <div style={{
-              fontSize: '12px',
-              color: colors.text.secondary,
-              marginTop: spacing.xs,
-            }}>
-              形式: {recConfig.ext} / {(audioBlob.size / 1024).toFixed(1)} KB
-            </div>
-          </div>
-        )}
-
-        {/* 文字起こし結果 */}
         {transcription && (
           <div
             style={{
-              marginTop: spacing.md,
-              padding: spacing.md,
-              borderRadius: borderRadius.medium,
-              border: `1px solid ${colors.border.light}`,
-              background: colors.background.white,
-              boxShadow: colors.shadow.light,
-              width: '100%',
-              maxWidth: '320px',
-              textAlign: 'center',
+              marginTop: 12,
+              padding: 12,
+              borderRadius: 12,
+              border: '1px solid #e5e7eb',
+              background: '#fff',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+              width: '92%',
+              maxWidth: `${Math.min(LAYOUT.cardMaxWidth, LAYOUT.maxWidth)}px`,
+              textAlign: 'center' as const,
             }}
           >
-            <div style={{
-              fontWeight: 700,
-              marginBottom: spacing.xs,
-              color: colors.text.primary,
-            }}>
-              文字起こし
-            </div>
-            <div style={{
-              whiteSpace: 'pre-wrap',
-              lineHeight: 1.6,
-              color: colors.text.primary,
-            }}>
+            <div style={{ fontWeight: 700, marginBottom: 6, color: '#111827' }}>文字起こし</div>
+            <div style={{ whiteSpace: 'pre-wrap', lineHeight: 1.6, color: '#111827' }}>
               {transcription.text || '—'}
             </div>
             {typeof transcription.confidence === 'number' && (
-              <div style={{
-                fontSize: '12px',
-                color: colors.text.secondary,
-                marginTop: spacing.sm,
-              }}>
+              <div style={{ fontSize: 12, color: '#6b7280', marginTop: 8 }}>
                 信頼度: {(transcription.confidence * 100).toFixed(1)}%
               </div>
             )}
           </div>
         )}
       </main>
+
+      {/* === 待ち時間の楽しいオーバーレイ（isBusy中だけ表示） === */}
+      {isBusy && (
+        <div style={styles.overlay} role="dialog" aria-live="polite" aria-label="よみこみ中">
+          <div style={styles.waitCard}>
+            <img
+              src="/images/kokoron/kokoron_mic.webp"
+              alt="こころん"
+              style={styles.waitKokoron}
+            />
+            <div style={styles.waitBubble}>{WAIT_MESSAGES[msgIndex]}</div>
+            <div style={styles.progressWrap}>
+              <div style={styles.progressBar} />
+            </div>
+            <div style={styles.waitHint}>よみこみ中だよ… そのまま まっててね</div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/voice.ts
+++ b/frontend/src/lib/voice.ts
@@ -77,7 +77,7 @@ export async function transcribe(opts: {
   const res = await fetch(`${API_BASE}/api/v1/voice/transcribe`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    // バックエンドは「S3キー or s3://」を受けられるので“キー”でOK
+    // バックエンドはS3キーのみを受け取る
     body: JSON.stringify({
       user_id: opts.userId,
       audio_file_path: opts.audioKey,


### PR DESCRIPTION
## 概要

音声記録フロー（感情確認 → 録音 → 完了 → 今日の記録）を改善しました。
S3取り扱いの統一、日次制約の実装/改善、UI/遷移の整理、デバッグ性向上、細かな不具合修正を含みます。

## 変更内容
制約/仕様
- 開発用途での日次・月次制限の一時無効化を追加（開発体験向上）
- 1日1件制約を本番想定で実装し、チェック処理を改善
- VoiceSaveRequest に voice_note フィールドを追加し、DB保存まで実装
- **S3の取り扱いを「キー統一」**に変更
voice.py / schemas.py からS3 URI利用を削除（S3 URLは使わずキーのみ）
- file_ops.py は 公開時はHTTPS URLを生成する形に整理
- 変数名の整理とnull安全性の改善
- スキーマ内のハードコードUUIDを廃止し汎用化

画面/遷移/UI
- 感情確認 → 録音画面への遷移時に child と redirect パラメータを付与
- 録音完了後の遷移先を /app/voice/complete に統一
- todayページ と 完了画面 を新規追加
- 録音ページに自動再生（オーディオ）機能を追加
- 音声解錠処理の削除により二重再生問題を解消

UIを大幅にブラッシュアップ（操作導線/見た目の改善）

その他
- 絵文字をテキストプレフィックスへ変換（文字化け対策）
- 音声認識のデバッグログを追加（原因調査を容易に）

- 変更の種類（複数選択可）:
  - [x] 機能追加（Feature）
  - [x] バグ修正（Fix）
  - [x] リファクタリング
  - [ ] ドキュメント整備
  - [ ] CI/CDや設定の変更
  - [ ] その他

## テスト・動作確認

遷移と制約
- 感情確認画面 → 録音画面へ遷移時に child と redirect がクエリに付与されること
- 開発モードでは日次/月次制限が無効であることを確認
- 本番想定フラグ/設定では「1日1件制約」が発火すること（同日2件目でブロック/ガード表示）
 録音～保存
- 音声録音 → アップロード → 保存まで完了し、voice_note と S3キーがDBに保存されること
- S3はキー保存で統一
- UI/挙動
- 録音ページで音声が自動再生されること
- 録音完了時に /app/voice/complete へリダイレクトされること
- todayページ に最新記録が反映されること
- 絵文字プレフィックス変換により文字化けが発生しないこと
- 回帰
- 変数リネーム/Null安全対応箇所でエラーが出ないこと（録音～保存フロー）
- ハードコードUUID廃止に伴う保存/参照の整合性が保たれていること
- 二重再生が再発しないこと

## UI変更がある場合（フロント向け）

<!-- Before / After の画像を貼るとベター（なければ削除OK） -->

## 関連Issue

<!-- 例: close #123 など -->

## 補足

<!-- レビューする人に伝えておきたいことがあればここに -->
