### PR TITLE
fix: 感情選択・確認画面のUI改善とこころんの配置調整

### DIFF
--- a/frontend/src/app/(authed)/app/emotion-confirmation/page.tsx
+++ b/frontend/src/app/(authed)/app/emotion-confirmation/page.tsx
@@ -441,14 +441,14 @@ export default function EmotionConfirmationPage() {
         ← もどる
       </button>
 
-      {/* こころんと吹き出し（右側に配置） */}
+      {/* こころんと吹き出し*/}
       <div style={{
         position: 'fixed',
         top: '100px',
         right: '2px',
         zIndex: 250,
       }}>
-        <KokoronDefault size={80} />
+        <KokoronDefault size={100} />
       </div>
       
       {/* 感情の説明文（白い四角） */}
@@ -676,8 +676,8 @@ export default function EmotionConfirmationPage() {
             animation: 'fadeIn 0.5s ease-in',
           }}>
             {swipeDirection === 'right' 
-              ? '感情確認完了！次の画面に進みます...' 
-              : '感情選択に戻ります...'
+              ? 'OK！つぎにすすむよ〜' 
+              : 'もういちど　きもちを　えらぼうね'
             }
           </div>
         )}

--- a/frontend/src/app/(authed)/app/emotion-intensity/page.tsx
+++ b/frontend/src/app/(authed)/app/emotion-intensity/page.tsx
@@ -385,14 +385,14 @@ export default function EmotionIntensityPage() {
         ← もどる
       </button>
 
-      {/* デフォルトのこころん（右側に配置） */}
+      {/* デフォルトのこころん*/}
       <div style={{
         position: 'fixed',
-        top: '100px',
+        top: '130px',
         right: '2px',
         zIndex: 250,
       }}>
-        <KokoronDefault size={80} />
+        <KokoronDefault size={100} />
       </div>
 
       {/* エラーメッセージ */}

--- a/frontend/src/app/(authed)/app/emotion-selection/page.tsx
+++ b/frontend/src/app/(authed)/app/emotion-selection/page.tsx
@@ -165,11 +165,11 @@ export default function EmotionSelectionPage() {
       {/* デフォルトのこころん（右側に配置） */}
       <div style={{
         position: 'fixed',
-        top: '80px',
-        right: '2px',
+        top: '110px',
+        right: '20px',
         zIndex: 250,
       }}>
-        <KokoronDefault size={80} />
+        <KokoronDefault size={100} />
       </div>
       
       {/* エラーメッセージ */}


### PR DESCRIPTION
## 概要

- こころんの配置とサイズ調整
  - 感情選択画面でのこころんの位置を右上に最適化
  - サイズを80pxから100pxに拡大して視認性向上
- UI/UX改善
  - 感情選択・確認画面のレイアウト調整
  - 画面遷移時のメッセージを子供向けに変更


## 変更内容

- 変更の種類（複数選択可）:
  - [ ] 機能追加（Feature）
  - [x] バグ修正（Fix）
  - [ ] リファクタリング
  - [ ] ドキュメント整備
  - [ ] CI/CDや設定の変更
  - [x] その他

## テスト・動作確認

開発者画面でのこころんの表示確認


## UI変更がある場合（フロント向け）
![IMG_CC9809D19DAF-1](https://github.com/user-attachments/assets/db896437-547f-470e-8c4d-45a3b7286436)
![IMG_1658902FB56D-1](https://github.com/user-attachments/assets/20eeebef-a453-4701-b2b5-579baa697ba5)
![IMG_05EBB1255A70-1](https://github.com/user-attachments/assets/306d9975-7fcb-471c-bce2-1375dcb96fa7)

